### PR TITLE
Feat/dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"@playwright/test": "^1.28.1",
 				"@sveltejs/adapter-auto": "^2.0.0",
 				"@sveltejs/adapter-static": "^2.0.1",
-				"@sveltejs/kit": "^1.10.0",
+				"@sveltejs/kit": "^1.12.0",
 				"@types/bootstrap": "^5.2.6",
 				"@types/cookie": "^0.5.1",
 				"@types/node": "^18.15.3",
@@ -782,9 +782,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.10.0.tgz",
-			"integrity": "sha512-0P35zHrByfbF3Ym3RdQL+RvzgsCDSyO3imSwuZ67XAD5HoCQFF3a8Mhh0V3sObz3rc5aJd4Qn82UpAihJqZ6gQ==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.12.0.tgz",
+			"integrity": "sha512-hhOtaL3jS7p4A3O34m8RlM+K5OSyrEyFUIh4iqsv6e8BDvupzNSxGa7J9+Gfjb+Z1yZCxjvxJ8Flb2Cj0g8cLg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -800,7 +800,7 @@
 				"set-cookie-parser": "^2.5.1",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.20.0"
+				"undici": "5.21.0"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -11498,9 +11498,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
 			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
@@ -12678,9 +12678,9 @@
 			"requires": {}
 		},
 		"@sveltejs/kit": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.10.0.tgz",
-			"integrity": "sha512-0P35zHrByfbF3Ym3RdQL+RvzgsCDSyO3imSwuZ67XAD5HoCQFF3a8Mhh0V3sObz3rc5aJd4Qn82UpAihJqZ6gQ==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.12.0.tgz",
+			"integrity": "sha512-hhOtaL3jS7p4A3O34m8RlM+K5OSyrEyFUIh4iqsv6e8BDvupzNSxGa7J9+Gfjb+Z1yZCxjvxJ8Flb2Cj0g8cLg==",
 			"dev": true,
 			"requires": {
 				"@sveltejs/vite-plugin-svelte": "^2.0.0",
@@ -12695,7 +12695,7 @@
 				"set-cookie-parser": "^2.5.1",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.20.0"
+				"undici": "5.21.0"
 			},
 			"dependencies": {
 				"magic-string": {
@@ -20958,9 +20958,9 @@
 			}
 		},
 		"undici": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
 			"dev": true,
 			"requires": {
 				"busboy": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"@micro-stacks/svelte": "^1.0.6",
 		"@noble/secp256k1": "^1.7.1",
 		"@scure/base": "^1.1.1",
-		"@scure/bip32": "^1.1.5",
+		"@scure/bip32": "^1.1.0",
 		"assert": "^2.0.0",
 		"big-integer": "^1.6.51",
 		"bip32": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@playwright/test": "^1.28.1",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/adapter-static": "^2.0.1",
-		"@sveltejs/kit": "^1.10.0",
+		"@sveltejs/kit": "^1.12.0",
 		"@types/bootstrap": "^5.2.6",
 		"@types/cookie": "^0.5.1",
 		"@types/node": "^18.15.3",


### PR DESCRIPTION
Fix for dependabot - updated "@scure/bip32": "^1.1.0" to 1.1.5 and broken compatibility with micro-stacks.